### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/python/projects/phiphi/phiphi/pipeline_jobs/utils.py
+++ b/python/projects/phiphi/phiphi/pipeline_jobs/utils.py
@@ -85,9 +85,10 @@ def read_data(query: str, dataset: str, table: str) -> pd.DataFrame:
         pd.DataFrame: The resulting DataFrame from the query.
     """
     if config.settings.USE_MOCK_BQ:
-        parquet_file_path = os.path.join(
-            config.settings.MOCK_BQ_ROOT_DIR, dataset, table + ".parquet"
-        )
+        base_path = config.settings.MOCK_BQ_ROOT_DIR
+        parquet_file_path = os.path.normpath(os.path.join(base_path, dataset, table + ".parquet"))
+        if not parquet_file_path.startswith(base_path):
+            raise Exception("Access to the specified path is not allowed.")
         if os.path.exists(parquet_file_path):
             full_table_df = pd.read_parquet(parquet_file_path)
             # Simulate SQL query using pandas query


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/phoenix/security/code-scanning/2](https://github.com/arpitjain099/phoenix/security/code-scanning/2)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root directory. This will prevent path traversal attacks.

1. Normalize the constructed path using `os.path.normpath`.
2. Check that the normalized path starts with the root directory (`config.settings.MOCK_BQ_ROOT_DIR`).
3. Raise an exception if the path is not within the root directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
